### PR TITLE
(feat) #12 branch coverage reduce method

### DIFF
--- a/javaparser-symbol-solver-core/pom.xml
+++ b/javaparser-symbol-solver-core/pom.xml
@@ -48,6 +48,25 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>jacoco-initialize</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Set JPMS module name -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/constraintformulas/TypeSameAsType.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/constraintformulas/TypeSameAsType.java
@@ -39,66 +39,100 @@ public class TypeSameAsType extends ConstraintFormula {
     private ResolvedType S;
     private ResolvedType T;
 
+    public static boolean[] reduceBranchesReached = new boolean[19];
+
     public TypeSameAsType(ResolvedType s, ResolvedType t) {
         S = s;
         T = t;
     }
 
+    public static void printReachedBranches(){
+        for (int i = 1; i < 19; i++)
+            System.out.print("Reduce Branch " + i + (reduceBranchesReached[i] ? "Reached" : "not Reached"));
+    }
+
     @Override
     public ReductionResult reduce(BoundSet currentBoundSet) {
         // A constraint formula of the form ‹S = T›, where S and T are types, is reduced as follows:
-
+        //id 1
+        reduceBranchesReached[1] = !S.isWildcard() || reduceBranchesReached[1];
         if (!S.isWildcard() && !T.isWildcard()) {
-
+            //id 2
+            reduceBranchesReached[2] = true;
             // - If S and T are proper types, the constraint reduces to true if S is the same as T (§4.3.4), and false
             //   otherwise.
-
+            //id 3
+            reduceBranchesReached[3] = isProperType(S) || reduceBranchesReached[3];
             if (isProperType(S) && isProperType(T)) {
+                //id 4
+                reduceBranchesReached[4] = true;
                 if (S.equals(T)) {
+                    //id 5
+                    reduceBranchesReached[5] = true;
                     return ReductionResult.trueResult();
                 } else {
+                    //id 6
+                    reduceBranchesReached[6] = true;
                     return ReductionResult.falseResult();
                 }
             }
 
             // - Otherwise, if S or T is the null type, the constraint reduces to false.
-
+            //id 7
+            reduceBranchesReached[7] = S.isNull();
             if (S.isNull() || T.isNull()) {
+                //id 8
+                reduceBranchesReached[8] = true;
                 return ReductionResult.falseResult();
             }
 
             // - Otherwise, if S is an inference variable, α, and T is not a primitive type, the constraint reduces to the
             //   bound α = T.
-
+            //id 9
+            reduceBranchesReached[9] = S.isInferenceVariable() || reduceBranchesReached[9];
             if (S.isInferenceVariable() && !T.isPrimitive()) {
+                //id 10
+                reduceBranchesReached[10] = true;
                 return ReductionResult.oneBound(new SameAsBound(S, T));
             }
 
             // - Otherwise, if T is an inference variable, α, and S is not a primitive type, the constraint reduces to the
             //   bound S = α.
-
+            //id 11
+            reduceBranchesReached[11] = T.isInferenceVariable() || reduceBranchesReached[9];
             if (T.isInferenceVariable() && !S.isPrimitive()) {
+                //id 12
+                reduceBranchesReached[12] = true;
                 return ReductionResult.oneBound(new SameAsBound(S, T));
             }
 
             // - Otherwise, if S and T are class or interface types with the same erasure, where S has
             //   type arguments B1, ..., Bn and T has type arguments A1, ..., An, the constraint reduces to the following
             //   new constraints: for all i (1 ≤ i ≤ n), ‹Bi = Ai›.
-
+            //id 13, 14
+            reduceBranchesReached[13] = S.isReferenceType() || reduceBranchesReached[13];
+            reduceBranchesReached[14] = T.isReferenceType() || reduceBranchesReached[14];
             if (S.isReferenceType() && T.isReferenceType()
                     && S.asReferenceType().toRawType().equals(T.asReferenceType().toRawType())) {
+                //id 15
+                reduceBranchesReached[15] = true;
                 ReductionResult res = ReductionResult.empty();
                 List<ResolvedType> Bs = S.asReferenceType().typeParametersValues();
                 List<ResolvedType> As = T.asReferenceType().typeParametersValues();
                 for (int i = 0; i < Bs.size(); i++) {
+                    //id 16
+                    reduceBranchesReached[16] = true;
                     res = res.withConstraint(new TypeSameAsType(Bs.get(i), As.get(i)));
                 }
                 return res;
             }
 
             // - Otherwise, if S and T are array types, S'[] and T'[], the constraint reduces to ‹S' = T'›.
-
+            //id 17
+            reduceBranchesReached[17] = S.isArray() || reduceBranchesReached[17];
             if (S.isArray() && T.isArray()) {
+                //id 18
+                reduceBranchesReached[18] = true;
                 return ReductionResult.oneConstraint(new TypeSameAsType(
                         S.asArrayType().getComponentType(),
                         T.asArrayType().getComponentType()));

--- a/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/constraintformulas/TypeSameAsType.java
+++ b/javaparser-symbol-solver-core/src/main/java/com/github/javaparser/symbolsolver/resolution/typeinference/constraintformulas/TypeSameAsType.java
@@ -48,7 +48,7 @@ public class TypeSameAsType extends ConstraintFormula {
 
     public static void printReachedBranches(){
         for (int i = 1; i < 19; i++)
-            System.out.print("Reduce Branch " + i + (reduceBranchesReached[i] ? "Reached" : "not Reached"));
+            System.out.println("Reduce Branch " + i + (reduceBranchesReached[i] ? "Reached" : "not Reached"));
     }
 
     @Override

--- a/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/constraintformulas/ConstraintFormulaTest.java
+++ b/javaparser-symbol-solver-testing/src/test/java/com/github/javaparser/symbolsolver/resolution/typeinference/constraintformulas/ConstraintFormulaTest.java
@@ -31,6 +31,7 @@ import com.github.javaparser.symbolsolver.resolution.typeinference.BoundSet;
 import com.github.javaparser.symbolsolver.resolution.typeinference.ConstraintFormula;
 import com.github.javaparser.symbolsolver.resolution.typeinference.InferenceVariable;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -64,6 +65,10 @@ class ConstraintFormulaTest {
         assertEquals(
                 ConstraintFormula.ReductionResult.empty().withConstraint(new TypeSubtypeOfType(typeSolver, stringType, inferenceVariable)),
                 res1.getConstraint(0).reduce(BoundSet.empty()));
+    }
+    @AfterAll
+    static void printReduceCoverage() {
+        TypeSameAsType.printReachedBranches();
     }
 
 //    /**


### PR DESCRIPTION
Added a simple branch coverage tool for the reduce method in the TypeSameAsType class in the symbolsolver project.

Also added Jacoco to this project to be able to compare results with another tool.